### PR TITLE
It Works!!! Versioned trait support with compile-time version enforcement

### DIFF
--- a/src/binary_serializer.rs
+++ b/src/binary_serializer.rs
@@ -2,11 +2,14 @@ use crate::version::Version;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-pub trait BinarySerializer<const VER_MAJOR: u16, const VER_MINOR: u16> {
+pub trait BinarySerializer {
+    const MAJOR: u16;
+    const MINOR: u16;
+
     fn version() -> Version {
         Version {
-            major: VER_MAJOR,
-            minor: VER_MINOR,
+            major: Self::MAJOR,
+            minor: Self::MINOR,
         }
     }
 
@@ -14,17 +17,17 @@ pub trait BinarySerializer<const VER_MAJOR: u16, const VER_MINOR: u16> {
 
     fn serialize_no_version<T: ?Sized>(value: &T) -> Result<Vec<u8>>
     where
-        T: Serialize; // + Versioned
+        T: Serialize;
 
     fn deserialize_no_version<'a, T>(bytes: &'a [u8]) -> Result<T>
     where
-        T: Deserialize<'a>; // + Versioned
+        T: Deserialize<'a>;
 
     fn serialize<T: ?Sized>(value: &T) -> Result<Vec<u8>>
     where
-        T: Serialize; // + Versioned;
+        T: Serialize;
 
     fn deserialize<'a, T>(bytes: &'a [u8]) -> Result<T>
     where
-        T: Deserialize<'a>; // + Versioned;
+        T: Deserialize<'a>;
 }

--- a/src/bincode_serializer.rs
+++ b/src/bincode_serializer.rs
@@ -1,14 +1,15 @@
 use std::io::Write;
 
-use crate::{binary_serializer::BinarySerializer, version::Version};
+use crate::{binary_serializer::BinarySerializer, version::Version, versioned::Versioned};
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
 pub struct BincodeSerializer<const VER_MAJOR: u16, const VER_MINOR: u16>;
-
-impl<const VER_MAJOR: u16, const VER_MINOR: u16> BinarySerializer<VER_MAJOR, VER_MINOR>
+impl<const VER_MAJOR: u16, const VER_MINOR: u16> BinarySerializer
     for BincodeSerializer<VER_MAJOR, VER_MINOR>
 {
+    const MAJOR: u16 = VER_MAJOR;
+    const MINOR: u16 = VER_MINOR;
     fn serialize_no_version<T: ?Sized>(value: &T) -> Result<Vec<u8>>
     where
         T: Serialize,
@@ -48,18 +49,125 @@ impl<const VER_MAJOR: u16, const VER_MINOR: u16> BinarySerializer<VER_MAJOR, VER
     }
 }
 
+// Testing; will use to replace BincodeSerializer after applying `Versioned` to existing serialized types
+pub struct VersionChecker<const VER_MAJOR: u16, const VER_MINOR: u16, TYPE: ?Sized + Versioned> {
+    _phantom: std::marker::PhantomData<TYPE>,
+}
+impl<const VER_MAJOR: u16, const VER_MINOR: u16, TYPE: ?Sized + Versioned>
+    VersionChecker<VER_MAJOR, VER_MINOR, TYPE>
+{
+    pub const VERSION_MISMATCH: () = if VER_MAJOR < TYPE::MIN_MAJOR
+        || VER_MAJOR > TYPE::MAX_MAJOR
+        || (VER_MAJOR == TYPE::MIN_MAJOR && VER_MINOR < TYPE::MIN_MINOR)
+        || (VER_MAJOR == TYPE::MAX_MAJOR && VER_MINOR > TYPE::MAX_MINOR)
+    {
+        panic!("unsupported type for version")
+    };
+}
+
+pub trait VersionedBinarySerializer {
+    const MAJOR: u16;
+    const MINOR: u16;
+
+    fn version() -> Version {
+        Version {
+            major: Self::MAJOR,
+            minor: Self::MINOR,
+        }
+    }
+
+    // TODO: `Versioned` trait
+
+    fn serialize_no_version<T: ?Sized>(value: &T) -> Result<Vec<u8>>
+    where
+        T: Serialize + Versioned;
+
+    fn deserialize_no_version<'a, T>(bytes: &'a [u8]) -> Result<T>
+    where
+        T: Deserialize<'a> + Versioned;
+
+    fn serialize<T: ?Sized>(value: &T) -> Result<Vec<u8>>
+    where
+        T: Serialize + Versioned;
+
+    fn deserialize<'a, T>(bytes: &'a [u8]) -> Result<T>
+    where
+        T: Deserialize<'a> + Versioned;
+}
+
+pub struct VersionedBincodeSerializer<const VER_MAJOR: u16, const VER_MINOR: u16>;
+impl<const VER_MAJOR: u16, const VER_MINOR: u16> VersionedBinarySerializer
+    for VersionedBincodeSerializer<VER_MAJOR, VER_MINOR>
+{
+    const MAJOR: u16 = VER_MAJOR;
+    const MINOR: u16 = VER_MINOR;
+
+    fn serialize_no_version<T: ?Sized>(value: &T) -> Result<Vec<u8>>
+    where
+        T: Serialize + Versioned,
+    {
+        #[allow(clippy::let_unit_value)]
+        let _ = VersionChecker::<VER_MAJOR, VER_MINOR, T>::VERSION_MISMATCH;
+
+        Ok(bincode::serialize(value)?)
+    }
+
+    fn deserialize_no_version<'a, T>(bytes: &'a [u8]) -> Result<T>
+    where
+        T: Deserialize<'a> + Versioned,
+    {
+        #[allow(clippy::let_unit_value)]
+        let _ = VersionChecker::<VER_MAJOR, VER_MINOR, T>::VERSION_MISMATCH;
+
+        Ok(bincode::deserialize(bytes)?)
+    }
+
+    fn serialize<T: ?Sized>(value: &T) -> Result<Vec<u8>>
+    where
+        T: Serialize + Versioned,
+    {
+        #[allow(clippy::let_unit_value)]
+        let _ = VersionChecker::<VER_MAJOR, VER_MINOR, T>::VERSION_MISMATCH;
+
+        let mut vec = Self::version().serialize();
+        bincode::serialize_into(vec.by_ref(), value)?;
+        Ok(vec)
+    }
+
+    fn deserialize<'a, T>(bytes: &'a [u8]) -> Result<T>
+    where
+        T: Deserialize<'a> + Versioned,
+    {
+        #[allow(clippy::let_unit_value)]
+        let _ = VersionChecker::<VER_MAJOR, VER_MINOR, T>::VERSION_MISMATCH;
+
+        let (ver, rest) = Version::deserialize(bytes)?;
+        if ver.major != VER_MAJOR || ver.minor != VER_MINOR {
+            return Err(anyhow!(
+                "Version Mismatch! Expected {}, got {}",
+                ver,
+                Self::version()
+            ));
+        }
+        Ok(bincode::deserialize(rest)?)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use serde::{Deserialize, Serialize};
 
     use crate::{binary_serializer::BinarySerializer, version::Version};
 
-    use super::BincodeSerializer;
+    use super::{BincodeSerializer, VersionedBinarySerializer, VersionedBincodeSerializer};
 
     mod version_0_1 {
+        use crate::versioned::Versioned;
+
         use super::*;
 
         pub type Serializer = BincodeSerializer<0u16, 1u16>;
+        pub type VSerializer = VersionedBincodeSerializer<0u16, 1u16>;
 
         #[derive(Serialize, Deserialize)]
         pub struct Thing {
@@ -67,18 +175,43 @@ mod test {
             pub field2: String,
             pub field3: u64,
         }
+
+        impl Versioned for Thing {
+            const MIN_MAJOR: u16 = 0;
+            const MIN_MINOR: u16 = 1;
+            const MAX_MAJOR: u16 = 0;
+            const MAX_MINOR: u16 = 2;
+        }
     }
 
     mod version_0_2 {
         use super::*;
 
         pub type Serializer = BincodeSerializer<0u16, 2u16>;
+        pub type VSerializer = VersionedBincodeSerializer<0u16, 2u16>;
+
+        pub type Thing = version_0_1::Thing;
+    }
+
+    mod version_0_3 {
+        use crate::versioned::Versioned;
+
+        use super::*;
+
+        pub type Serializer = BincodeSerializer<0u16, 3u16>;
+        pub type VSerializer = VersionedBincodeSerializer<0u16, 3u16>;
 
         #[derive(Serialize, Deserialize)]
         pub struct Thing {
             pub field1: u64,
             pub field2: String,
             pub field3: u64,
+        }
+        impl Versioned for Thing {
+            const MIN_MAJOR: u16 = 0;
+            const MIN_MINOR: u16 = 3;
+            const MAX_MAJOR: u16 = 0;
+            const MAX_MINOR: u16 = 3;
         }
     }
 
@@ -98,10 +231,39 @@ mod test {
 
         let thing_out = version_0_1::Serializer::deserialize::<version_0_1::Thing>(&buf);
         assert!(thing_out.is_ok());
-        // With Versioned, we will want these to fail at compile time if Thing is changes between v 0.1 and v 0.2, and pass otherwise.
+        // this behavior is not what we want...
         let ver_err_out = version_0_2::Serializer::deserialize::<version_0_1::Thing>(&buf);
         assert!(ver_err_out.is_err());
-        let type_err_out = version_0_2::Serializer::deserialize::<version_0_2::Thing>(&buf);
+        let ver_err_out = version_0_3::Serializer::deserialize::<version_0_1::Thing>(&buf);
+        assert!(ver_err_out.is_err());
+        let type_err_out = version_0_3::Serializer::deserialize::<version_0_3::Thing>(&buf);
+        assert!(type_err_out.is_err());
+    }
+
+    #[test]
+    fn version_in_version_out_versioned() {
+        let thing_in = version_0_1::Thing {
+            field1: 0,
+            field2: "0.1".to_string(),
+            field3: 1,
+        };
+
+        let buf = version_0_1::VSerializer::serialize(&thing_in).unwrap();
+
+        let version_in = version_0_1::VSerializer::version();
+        let (version_out, _) = Version::deserialize(&buf).unwrap();
+        assert_eq!(version_in, version_out);
+
+        let thing_out = version_0_1::VSerializer::deserialize::<version_0_1::Thing>(&buf);
+        assert!(thing_out.is_ok());
+        let ver_err_out = version_0_2::VSerializer::deserialize::<version_0_1::Thing>(&buf);
+        assert!(ver_err_out.is_err());
+        let ver_err_out = version_0_2::VSerializer::deserialize::<version_0_2::Thing>(&buf);
+        assert!(ver_err_out.is_err());
+        // the following test fails at compile time, as desired.
+        // let ver_err_out = version_0_3::VSerializer::deserialize::<version_0_1::Thing>(&buf);
+        // assert!(ver_err_out.is_err());
+        let type_err_out = version_0_3::VSerializer::deserialize::<version_0_3::Thing>(&buf);
         assert!(type_err_out.is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod binary_serializer;
 pub mod bincode_serializer;
 pub mod version;
+pub mod versioned;
 
 pub type BinarySerializer<const MAJOR: u16, const MINOR: u16> =
     bincode_serializer::BincodeSerializer<MAJOR, MINOR>;

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -1,0 +1,6 @@
+pub trait Versioned {
+    const MIN_MAJOR: u16;
+    const MIN_MINOR: u16;
+    const MAX_MAJOR: u16;
+    const MAX_MINOR: u16;
+}


### PR DESCRIPTION
Not turned on until we implement Versioned for Serialize types; I'm trying to figure out if I can come up with a way to apply a module-controlled impl-trait-for-trait solution to apply a different `impl<const MAJOR: u16, const MINOR: u16> VersionedHelper<MAJOR, MINOR> for T where T: Serialize` in each versioning module, and somehow integrate them into an `impl Versioned for T where T: Serialize {...}`...

A derive macro execution won't provide access to the versions, because they won't be visible at that time.
Rust does not have a variadic or recursive constraint syntax, which I could otherwise use to pin the version range.

Maybe we just do it the hard way, and for each type, explicitly set the version range, something like:
```rust
mod ver_0_1 {
#[derive(..., Versioned, ...)]
#[valid_versions(0, 1, 0, 3)]
struct MyType {...}
}
```
