### PR TITLE
Improve Display for Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vbs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Espresso Systems <hello@espressosys.com>"]
@@ -12,7 +12,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0"
+derive_more = "0.99"
 bincode = "1.3"
-displaydoc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "3.4"

--- a/src/version.rs
+++ b/src/version.rs
@@ -50,6 +50,7 @@ pub trait StaticVersionType: Sync + Send + Clone + Copy + Debug + private::Seale
 }
 
 #[derive(Clone, Copy, Display)]
+#[display(fmt = "{MAJOR}.{MINOR}")]
 pub struct StaticVersion<const MAJOR: u16, const MINOR: u16> {}
 
 impl<const MAJOR: u16, const MINOR: u16> StaticVersionType for StaticVersion<MAJOR, MINOR> {
@@ -91,5 +92,10 @@ mod test {
     #[test]
     fn test_version_display() {
         assert_eq!("1.2", Version { major: 1, minor: 2 }.to_string());
+    }
+
+    #[test]
+    fn test_static_version_display() {
+        assert_eq!("1.2", StaticVersion::<1, 2> {}.to_string());
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,10 +1,11 @@
 use anyhow::anyhow;
 use core::fmt::Debug;
-use displaydoc::Display;
+use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, Display, Eq, Hash, PartialEq, Serialize)]
 /// Type for protocol version number
+#[display(fmt = "{major}.{minor}")]
 pub struct Version {
     /// major version number
     pub major: u16,
@@ -81,4 +82,14 @@ mod private {
 
     // Implement for those same types, but no others.
     impl<const MAJOR: u16, const MINOR: u16> Sealed for super::StaticVersion<MAJOR, MINOR> {}
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_version_display() {
+        assert_eq!("1.2", Version { major: 1, minor: 2 }.to_string());
+    }
 }


### PR DESCRIPTION
The previous implementation simply printed the struct's docstring, which is not very useful. The new implementation prints a specific version in {major}.{minor} format, which makes for better error messages when deserialization fails due to version mismatch.