### PR TITLE
Adding a `const VERSION: Version` to `StaticVersionType`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vbs"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Espresso Systems <hello@espressosys.com>"]

--- a/src/version.rs
+++ b/src/version.rs
@@ -40,12 +40,13 @@ impl Version {
 pub trait StaticVersionType: Sync + Send + Clone + Copy + Debug + private::Sealed {
     const MAJOR: u16;
     const MINOR: u16;
+    const VERSION: Version = Version {
+        major: Self::MAJOR,
+        minor: Self::MINOR,
+    };
 
     fn version() -> Version {
-        Version {
-            major: Self::MAJOR,
-            minor: Self::MINOR,
-        }
+        Self::VERSION
     }
 
     fn instance() -> Self;
@@ -117,5 +118,17 @@ mod test {
     #[test]
     fn test_static_version_display() {
         assert_eq!("1.2", StaticVersion::<1, 2> {}.to_string());
+    }
+
+    #[test]
+    fn test_static_version_const() {
+        assert_eq!(
+            StaticVersion::<1, 2>::VERSION,
+            StaticVersion::<1, 2>::version()
+        );
+        assert_eq!(
+            Version { major: 1, minor: 2 },
+            StaticVersion::<1, 2>::version()
+        );
     }
 }


### PR DESCRIPTION
Minor ergonomics request from @ss-es 

### This PR:
- Adds an associated `const VERSION: Version` to `StaticVersionType`
- Ensures that it is default initialized for every `StaticVersion`.

### This PR does not:

### Key places to review:

<!-- ### How to test this PR:  -->
Added test `test_static_version_const`

<!-- ### Things tested -->
The const VERSION is, as expected, equal to a non-static Version with the same major.minor value

